### PR TITLE
fix getBlocksForRange block number format

### DIFF
--- a/getBlocksForRange.js
+++ b/getBlocksForRange.js
@@ -29,9 +29,7 @@ function incrementHexInt(hexString){
 
 function intToHex(int) {
   if (int === undefined || int === null) return int
-  let hexString = int.toString(16)
-  const needsLeftPad = hexString.length % 2
-  if (needsLeftPad) hexString = '0' + hexString
+  const hexString = int.toString(16)
   return '0x' + hexString
 }
 


### PR DESCRIPTION
as per current JSON RPC spec, blockNumber does not need to be padded. 

```
curl -X POST \
  https://mainnet.infura.io \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x5dcd0", false],"id":123}'
```
works fine, while
```
curl -X POST \
  https://mainnet.infura.io \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["0x05dcd0", false],"id":123}'
```
produces error `"error":{"code":-32602,"message":"invalid argument 0: hex number with leading zero digits"}`

Currently it's working fine because we have even number of hex characters for block height at the moment