### PR TITLE
Update minimum eth-json-rpc-middleware version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "await-semaphore": "^0.1.3",
-    "eth-json-rpc-middleware": "^4.1.4",
+    "eth-json-rpc-middleware": "^4.4.0",
     "eth-query": "^2.1.2",
     "json-rpc-engine": "^5.1.3",
     "lodash.flatmap": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2199,7 +2199,7 @@ eth-json-rpc-middleware@^1.5.0:
     promise-to-callback "^1.0.0"
     tape "^4.6.3"
 
-eth-json-rpc-middleware@^4.1.4:
+eth-json-rpc-middleware@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz#07d3dd0724c24a8d31e4a172ee96271da71b4228"
   integrity sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==


### PR DESCRIPTION
Closes #12

This PR bumps the minimum `eth-json-rpc-middleware` version in the `package.json` file.