### PR TITLE
Specify publish files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "lint": "printf '%s\\n' 'No lint command'",
     "test": "node test"
   },
-  "author": "",
   "license": "ISC",
   "resolutions": {
     "ganache-core/**/elliptic": "^6.4.1",
@@ -15,6 +14,9 @@
     "ganache-core/**/mkdirp": "^0.5.5",
     "ganache-core/websocket": "^1.0.32"
   },
+  "files": [
+    "*.js"
+  ],
   "dependencies": {
     "await-semaphore": "^0.1.3",
     "eth-json-rpc-middleware": "^6.0.0",


### PR DESCRIPTION
Add `files` property to `package.json`.

```
> npm pack --dry-run
npm notice 📦  eth-json-rpc-filters@4.2.0
npm notice === Tarball Contents === 
npm notice 739B  LICENSE               
npm notice 645B  base-filter-history.js
npm notice 594B  base-filter.js        
npm notice 650B  block-filter.js       
npm notice 1.4kB getBlocksForRange.js  
npm notice 1.6kB hexUtils.js           
npm notice 6.6kB index.js              
npm notice 3.6kB log-filter.js         
npm notice 4.4kB subscriptionManager.js
npm notice 694B  tx-filter.js          
npm notice 1.5kB package.json          
npm notice 545B  CHANGELOG.md          
npm notice 759B  README.md   
```