### PR TITLE
Update `json-rpc-engine` from v5 to v6

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const Mutex = require('async-mutex').Mutex
-const createAsyncMiddleware = require('json-rpc-engine/src/createAsyncMiddleware')
+const { createAsyncMiddleware } = require('json-rpc-engine')
 const createJsonRpcMiddleware = require('eth-json-rpc-middleware/scaffold')
 const LogFilter = require('./log-filter.js')
 const BlockFilter = require('./block-filter.js')

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "async-mutex": "^0.2.6",
     "eth-json-rpc-middleware": "^6.0.0",
     "eth-query": "^2.1.2",
-    "json-rpc-engine": "^5.3.0",
+    "json-rpc-engine": "^6.1.0",
     "lodash.flatmap": "^4.5.0",
     "pify": "^3.0.0",
     "safe-event-emitter": "^1.0.1"

--- a/subscriptionManager.js
+++ b/subscriptionManager.js
@@ -1,6 +1,6 @@
 const SafeEventEmitter = require('safe-event-emitter')
 const createScaffoldMiddleware = require('eth-json-rpc-middleware/scaffold')
-const createAsyncMiddleware = require('json-rpc-engine/src/createAsyncMiddleware')
+const { createAsyncMiddleware } = require('json-rpc-engine')
 const createFilterMiddleware = require('./index.js')
 const { unsafeRandomBytes, incrementHexInt } = require('./hexUtils.js')
 const getBlocksForRange = require('./getBlocksForRange.js')

--- a/test/util.js
+++ b/test/util.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events')
 const EthBlockTracker = require('eth-block-tracker')
 const EthQuery = require('ethjs-query')
-const JsonRpcEngine = require('json-rpc-engine')
+const { JsonRpcEngine } = require('json-rpc-engine')
 const providerAsMiddleware = require('eth-json-rpc-middleware/providerAsMiddleware')
 const providerFromEngine = require('eth-json-rpc-middleware/providerFromEngine')
 const GanacheCore = require('ganache-core')

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,11 @@
     "@ethersproject/properties" "^5.0.7"
     "@ethersproject/strings" "^5.0.8"
 
+"@metamask/safe-event-emitter@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
+  integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -2025,6 +2030,13 @@ eth-rpc-errors@^3.0.0:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
+eth-rpc-errors@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.2.tgz#11bc164e25237a679061ac05b7da7537b673d3b7"
+  integrity sha512-n+Re6Gu8XGyfFy1it0AwbD1x0MUzspQs0D5UiPs1fFPCr6WAwZM+vbIhXheBFrpgosqN9bs5PqlB4Q61U/QytQ==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 eth-sig-util@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-3.0.0.tgz#75133b3d7c20a5731af0690c385e184ab942b97e"
@@ -3316,6 +3328,14 @@ json-rpc-engine@^5.3.0:
   dependencies:
     eth-rpc-errors "^3.0.0"
     safe-event-emitter "^1.0.1"
+
+json-rpc-engine@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz#bf5ff7d029e1c1bf20cb6c0e9f348dcd8be5a393"
+  integrity sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==
+  dependencies:
+    "@metamask/safe-event-emitter" "^2.0.0"
+    eth-rpc-errors "^4.0.2"
 
 json-rpc-error@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
All uses of `json-rpc-engine` have been updated to account for the changes in package exports.