### PR TITLE
Replace `lodash.flatmap`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "eth-json-rpc-middleware": "^6.0.0",
     "eth-query": "^2.1.2",
     "json-rpc-engine": "^6.1.0",
-    "lodash.flatmap": "^4.5.0",
     "pify": "^3.0.0"
   },
   "devDependencies": {

--- a/tx-filter.js
+++ b/tx-filter.js
@@ -1,4 +1,3 @@
-const flatMap = require('lodash.flatmap')
 const BaseFilter = require('./base-filter')
 const getBlocksForRange = require('./getBlocksForRange')
 const { incrementHexInt } = require('./hexUtils')
@@ -15,7 +14,10 @@ class TxFilter extends BaseFilter {
     const toBlock = oldBlock
     const fromBlock = incrementHexInt(oldBlock)
     const blocks = await getBlocksForRange({ provider: this.provider, fromBlock, toBlock })
-    const blockTxHashes = flatMap(blocks, (block) => block.transactions)
+    const blockTxHashes = []
+    for (const block of blocks) {
+      blockTxHashes.push(...block.transactions)
+    }
     // add to results
     this.addResults(blockTxHashes)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3600,11 +3600,6 @@ levelup@^1.2.1:
     semver "~5.4.1"
     xtend "~4.0.0"
 
-lodash.flatmap@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
-  integrity sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=
-
 lodash@4.17.20, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"


### PR DESCRIPTION
`flatmap` is a great utility function, but, it didn't seem necessary here. The operation it was used for was trivial to implement using plain JavaScript. Removing this dependency leaves one less thing for us to update.