### PR TITLE
Move `pify` to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eth-query": "^2.1.2",
     "json-rpc-engine": "^5.3.0",
     "lodash.flatmap": "^4.5.0",
+    "pify": "^3.0.0",
     "safe-event-emitter": "^1.0.1"
   },
   "devDependencies": {
@@ -32,7 +33,6 @@
     "ethereumjs-util": "^6.1.0",
     "ethjs-query": "^0.3.8",
     "ganache-core": "^2.7.0",
-    "pify": "^3.0.0",
     "tape": "^4.9.1"
   },
   "directories": {


### PR DESCRIPTION
`pify` is used in the `log-filter` module, so it's not a development dependency.