### PR TITLE
Update `pify` to v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eth-json-rpc-middleware": "^6.0.0",
     "eth-query": "^2.1.2",
     "json-rpc-engine": "^6.1.0",
-    "pify": "^3.0.0"
+    "pify": "^5.0.0"
   },
   "devDependencies": {
     "eth-block-tracker": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4251,6 +4251,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
+  integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"


### PR DESCRIPTION
The only breaking change was the minimum node version required. The minimum Node.js version changed from v4 to v6 in `pify@4.0.0`, and it changed from v6 to v10 in `pify@5.0.0`.