### PR TITLE
Add minimum Node.js version of v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   "bugs": {
     "url": "https://github.com/kumavis/eth-json-rpc-filters/issues"
   },
-  "homepage": "https://github.com/kumavis/eth-json-rpc-filters#readme"
+  "homepage": "https://github.com/kumavis/eth-json-rpc-filters#readme",
+  "engines": {
+    "node": ">=v10"
+  }
 }


### PR DESCRIPTION
v10 is about to hit EOL, so I don't think we should support anything older than that. We certainly won't be testing with versions older than that.