### PR TITLE
Fix manifest repository links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth-json-rpc-filters",
   "version": "4.2.1",
-  "description": "[json-rpc-engine](https://github.com/kumavis/json-rpc-engine) middleware implementing ethereum filter methods. Backed by an [eth-block-tracker](https://github.com/MetaMask/eth-block-tracker) and web3 provider interface (`web3.currentProvider`).",
+  "description": "[json-rpc-engine](https://github.com/MetaMask/json-rpc-engine) middleware implementing ethereum filter methods. Backed by an [eth-block-tracker](https://github.com/MetaMask/eth-block-tracker) and web3 provider interface (`web3.currentProvider`).",
   "main": "index.js",
   "scripts": {
     "lint": "printf '%s\\n' 'No lint command'",
@@ -40,10 +40,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kumavis/eth-json-rpc-filters.git"
+    "url": "git+https://github.com/MetaMask/eth-json-rpc-filters.git"
   },
   "bugs": {
-    "url": "https://github.com/kumavis/eth-json-rpc-filters/issues"
+    "url": "https://github.com/MetaMask/eth-json-rpc-filters/issues"
   },
-  "homepage": "https://github.com/kumavis/eth-json-rpc-filters#readme"
+  "homepage": "https://github.com/MetaMask/eth-json-rpc-filters#readme"
 }


### PR DESCRIPTION
The manifest still referenced the old GitHub repository location, before it was transferred from `kumavis` to `MetaMask`.