### PR TITLE
Remove `directories` manifest property

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "pify": "^3.0.0",
     "tape": "^4.9.1"
   },
-  "directories": {
-    "test": "test"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kumavis/eth-json-rpc-filters.git"


### PR DESCRIPTION
This property doesn't seem to do anything ([according to the npm documentation](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#directoriestest)). We don't publish that directory anyway, so for any package consumers it points at a non-existent directory.