### PR TITLE
Remove `engines` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
   "bugs": {
     "url": "https://github.com/MetaMask/eth-json-rpc-filters/issues"
   },
-  "homepage": "https://github.com/MetaMask/eth-json-rpc-filters#readme",
-  "engines": {
-    "node": ">=v10"
-  }
+  "homepage": "https://github.com/MetaMask/eth-json-rpc-filters#readme"
 }


### PR DESCRIPTION
We still don't want to support Node.js version below v10, but this would make the next release a breaking change. This field is being temporarily removed so we can release a patch, then it will be restored.