### PR TITLE
Filter out null blocks

### DIFF
--- a/getBlocksForRange.js
+++ b/getBlocksForRange.js
@@ -13,7 +13,8 @@ async function getBlocksForRange({ provider, fromBlock, toBlock }) {
   const blockBodies = await Promise.all(
     missingBlockNumbers.map(blockNum => query(provider, 'eth_getBlockByNumber', [blockNum, false]))
   )
-  return blockBodies
+  const nonNullBlocks = blockBodies.filter(Boolean);
+  return nonNullBlocks
 }
 
 function hexToInt(hexString) {

--- a/subscriptionManager.js
+++ b/subscriptionManager.js
@@ -66,7 +66,7 @@ function createSubscriptionMiddleware({ blockTracker, provider }) {
           const toBlock = newBlock
           const fromBlock = incrementHexInt(oldBlock)
           const rawBlocks = await getBlocksForRange({ provider, fromBlock, toBlock })
-          const results = rawBlocks.map(normalizeBlock)
+          const results = rawBlocks.filter(Boolean).map(normalizeBlock)
           results.forEach((value) => {
             _emitSubscriptionResult(subId, value)
           })

--- a/subscriptionManager.js
+++ b/subscriptionManager.js
@@ -66,7 +66,7 @@ function createSubscriptionMiddleware({ blockTracker, provider }) {
           const toBlock = newBlock
           const fromBlock = incrementHexInt(oldBlock)
           const rawBlocks = await getBlocksForRange({ provider, fromBlock, toBlock })
-          const results = rawBlocks.filter(Boolean).map(normalizeBlock)
+          const results = rawBlocks.map(normalizeBlock)
           results.forEach((value) => {
             _emitSubscriptionResult(subId, value)
           })

--- a/test/getBlocksForRange.js
+++ b/test/getBlocksForRange.js
@@ -2,7 +2,6 @@ const sinon = require("sinon");
 const test = require("tape");
 
 const getBlocksForRange = require("../getBlocksForRange");
-
 test("return block number if there is no error", async (t) => {
   const sendAsync = sinon
     .stub()
@@ -49,6 +48,31 @@ test("looks for a block number 3 times until throwing", async (t) => {
     t.fail("Promise resolved when it was not supposed to");
   } catch (error) {
     t.equal(error.message, 'Block not found for params: ["0x1",false]');
+  }
+  t.end();
+});
+
+test("does not return null blocks", async (t) => {
+  const sendAsync = sinon
+    .stub()
+    .withArgs({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "eth_getBlockByNumber",
+      params: ["0x1", false],
+    })
+    .onCall(0)
+    .callsArgWith(1, null, { result: null });
+  const provider = { sendAsync };
+  try {
+    const result = await getBlocksForRange({
+      provider,
+      fromBlock: "0x1",
+      toBlock: "0x1",
+    });
+    t.deepEquals(result, []);
+  } catch (error) {
+    t.fail("Should not throw error if result is obtained");
   }
   t.end();
 });


### PR DESCRIPTION
Looking at the error that occurs the most in Sentry (https://sentry.io/organizations/metamask/issues/2052743196/?project=273505&query=is%3Aunresolved&sort=freq&statsPeriod=14d), it appears that we can receive null blocks:


```
node_modules/eth-json-rpc-filters/subscriptionManager.js in normalizeBlock
```

Since `normalizeBlock` presumes `block` has certain properties, it makes sense that we filter out bad `block` representations before trying to normalize them.