### PR TITLE
Fix: not throw error if block for a block number is not found

### DIFF
--- a/getBlocksForRange.js
+++ b/getBlocksForRange.js
@@ -64,5 +64,5 @@ async function query(provider, method, params) {
       );
     }
   }
-  throw new Error(`Block not found for params: ${JSON.stringify(params)}`);
+  return null;
 }

--- a/getBlocksForRange.js
+++ b/getBlocksForRange.js
@@ -10,9 +10,10 @@ async function getBlocksForRange({ provider, fromBlock, toBlock }) {
   const missingBlockNumbers = Array(blockCountToQuery).fill()
                               .map((_,index) => fromBlockNumber + index)
                               .map(intToHex)
-  const blockBodies = await Promise.all(
+  let blockBodies = await Promise.all(
     missingBlockNumbers.map(blockNum => query(provider, 'eth_getBlockByNumber', [blockNum, false]))
   )
+  blockBodies = blockBodies.filter(block => block !== null);
   return blockBodies
 }
 

--- a/test/getBlocksForRange.js
+++ b/test/getBlocksForRange.js
@@ -28,7 +28,7 @@ test("return block number if there is no error", async (t) => {
   t.end();
 });
 
-test("looks for a block number 3 times until throwing", async (t) => {
+test("looks for a block number 3 times and not throw error even if it fails", async (t) => {
   const sendAsync = sinon
     .stub()
     .withArgs({
@@ -45,10 +45,10 @@ test("looks for a block number 3 times until throwing", async (t) => {
     .callsArgWith(1, null, { result: null });
   const provider = { sendAsync };
   try {
-    await getBlocksForRange({ provider, fromBlock: "0x1", toBlock: "0x1" });
-    t.fail("Promise resolved when it was not supposed to");
+    const result = await getBlocksForRange({ provider, fromBlock: "0x1", toBlock: "0x1" });
+    t.deepEquals(result, [null]);
   } catch (error) {
-    t.equal(error.message, 'Block not found for params: ["0x1",false]');
+    t.fail("Should not throw error if result is obtained");
   }
   t.end();
 });

--- a/test/getBlocksForRange.js
+++ b/test/getBlocksForRange.js
@@ -28,7 +28,7 @@ test("return block number if there is no error", async (t) => {
   t.end();
 });
 
-test("looks for a block number 3 times and not throw error even if it fails", async (t) => {
+test("not throw error even if it is not found and filter out null", async (t) => {
   const sendAsync = sinon
     .stub()
     .withArgs({
@@ -46,7 +46,7 @@ test("looks for a block number 3 times and not throw error even if it fails", as
   const provider = { sendAsync };
   try {
     const result = await getBlocksForRange({ provider, fromBlock: "0x1", toBlock: "0x1" });
-    t.deepEquals(result, [null]);
+    t.deepEquals(result, []);
   } catch (error) {
     t.fail("Should not throw error if result is obtained");
   }


### PR DESCRIPTION
Related: 

https://metamask.sentry.io/issues/3937062518/?project=273505
https://github.com/MetaMask/metamask-extension/issues/17773

As eth-json-rpc-filters was upgraded in extension, new error was noticed in extension sentry logs. This PR fixes the error.

Discussion here: https://consensys.slack.com/archives/G1L7H42BT/p1676483338392309