### PR TITLE
chore: add publishConfig to package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
     "url": "https://github.com/MetaMask/eth-json-rpc-filters/issues"
   },
   "homepage": "https://github.com/MetaMask/eth-json-rpc-filters#readme",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,


### PR DESCRIPTION
This will be necessary before publishing #105 after the change to scoped in #103