### PR TITLE
BREAKING: drop support for Node.js v16, v21

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "[json-rpc-engine](https://github.com/MetaMask/json-rpc-engine) middleware implementing ethereum filter methods. Backed by an [eth-block-tracker](https://github.com/MetaMask/eth-block-tracker) and web3 provider interface (`web3.currentProvider`).",
   "main": "index.js",
   "engines": {
-    "node": "^16.20 || ^18.16 || >=20",
+    "node": "^18.16 || ^20 || >=22",
     "yarn": "^1.22.22"
   },
   "scripts": {


### PR DESCRIPTION
### Related
#### Blocked by
- [x] #172
  - [x] #163 
  - [x] #162 

#### Blocking
- [ ] #165