### PR TITLE
deps: @metamask/eth-block-tracker@^9.0.3->^10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@lavamoat/allow-scripts": "^2.5.1",
     "@metamask/auto-changelog": "^3.3.0",
     "@metamask/eth-json-rpc-middleware": "^13.0.0",
-    "@metamask/eth-block-tracker": "^10.0.0",
+    "@metamask/eth-block-tracker": "~10.0.0 || ^10.1.1",
     "ganache-cli": "^6.12.2",
     "sinon": "^15.2.0",
     "tape": "^5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,7 +95,7 @@
     semver "^7.3.5"
     yargs "^17.0.1"
 
-"@metamask/eth-block-tracker@^10.0.0":
+"@metamask/eth-block-tracker@^10.0.0", "@metamask/eth-block-tracker@~10.0.0 || ^10.1.1":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@metamask/eth-block-tracker/-/eth-block-tracker-10.0.0.tgz#22078b62cba7eb4df45381f3325231f8a07db316"
   integrity sha512-Fir1M6fUCR5HRVBL5DBKGV2TOsVfj5an23eggVRgGwY965i3TglMC2rA5IVA60rl6MxAHP//QQz5N/hK+uN7Hg==


### PR DESCRIPTION
- deps: @metamask/eth-json-rpc-middleware@^12.0.0->^13.0.0
- deps: @metamask/eth-block-tracker@^9.0.3->~^10.1.0~^10.0.0
  - 10.1.0 causes a regression here, so holding back at 10.0.0. 

#### Blocked by
- [x] #165 
  - [x] #164

#### Blocking
- #170
